### PR TITLE
Add file to make jupytext write Rmd files

### DIFF
--- a/jupytext.toml
+++ b/jupytext.toml
@@ -1,0 +1,3 @@
+# https://jupytext.readthedocs.io/en/latest/config.html
+# Pair ipynb notebooks to Rmd text notebooks
+formats = "ipynb,Rmd"


### PR DESCRIPTION
You will need this to make Jupytext work correctly, in writing out the
Rmd files from the notebook interface.